### PR TITLE
Proposed - Change env to dict to be able to add more readable configurations in the future

### DIFF
--- a/instance/env/development.py
+++ b/instance/env/development.py
@@ -1,19 +1,21 @@
 
-# Mongo db config
-MONGO_URI = '127.0.0.1'
-MONGO_HOST = 'localhost'
-MONGO_PORT = '27017'
-MONGO_CONNECT_TIMEOUT_MS = 10000
+Db = {
+    'connection': 'mysql',
 
+    'mongo': {
+        'host': '127.0.0.1',
+        'db': 'new_mlm',
+        'port': '27017',
+        'timeout': 10000,
+        'user': '',
+        'password': ''
+    },
 
-# MySQL Config
-# For multiple mysql connections, use object for each config,
-# the db driver will read and parse it as needed
-
-MYSQL_CONNECTION = {
-    'host': 'localhost',
-    'db': 'test_app',
-    'user': 'root',
-    'password': '',
-    'port': 3306
+    'mysql': {
+        'host': 'localhost',
+        'db': 'new_mlm',
+        'user': 'root',
+        'password': '',
+        'port': 3306
+    }
 }

--- a/lib/database_connection.py
+++ b/lib/database_connection.py
@@ -27,7 +27,8 @@ db = Database()
 # Database connections declaration
 # If you want global accessisble database, declare it here
 # It will automatically give you a connection from the connection pool
-db.test_app_db = db.add_engine(development.MYSQL_CONNECTION)
+db.test_app_db = db.add_engine(development.Db.get('mysql'))
+
 
 
 @mod_db_connection.teardown_app_request


### PR DESCRIPTION
- changed mysql and mongo to dict
- made mysql to use db.get

Todo: 
- make the `primary connection` work in the future. Be able to switch primary connection to either use mongo or mysql if needed
